### PR TITLE
Improve production readiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Data and model artifacts
+models/*.pkl
+results/
+statcast.db
+data/
+
+# Misc
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # MLB Tool Grades
 
-Can't run without adding a statcast.db file but too large of a file to worry about adding. You could also add one or collection of csv's of statcast data in the `data/statcast/` folder and run `python build_db.py`
+This project predicts and evaluates player hitting tools using pitch–by–pitch Statcast data.  LightGBM models estimate swing decisions, contact ability and exit velocity, while Bayesian methods quantify uncertainty around those grades.  An overall projection model combines the posterior samples to forecast future production.  The pipeline pulls data from a SQLite database, trains models with hyperparameter optimization, and generates 20–80 scaled grades with credible intervals.
 
-## Examples:
+The codebase demonstrates production best practices such as modular data pipelines, reproducible model training, and CLI entry points.  Models and features are persisted for reuse, and the build script can recreate the database from raw CSVs.  The project highlights skills in Python, SQL, machine learning and probabilistic modeling that align closely with the Dodgers’ analytics workflow.
 
-### Build Models
-`python train.py`
+## Usage
 
-### Create Grades
-`python get_grades.py --suffix=2024Grades --start_date=2024-04-01 --end_date=2024-12-31 --year=2024`
+```bash
+# Train component models
+python main.py train
+
+# Train overall projection model
+python main.py overall
+
+# Generate grades (requires trained models and Statcast DB)
+python main.py grades --suffix=2024Grades --start_date=2024-04-01 --end_date=2024-12-31 --year=2024
+```

--- a/main.py
+++ b/main.py
@@ -1,9 +1,28 @@
+import argparse
 import train
 import overall_model
+import get_grades
+
 
 def main():
-    train.main()
-    overall_model.main()
+    parser = argparse.ArgumentParser(description="MLB Tool Grades pipeline")
+    subparsers = parser.add_subparsers(dest="command")
+
+    subparsers.add_parser("train", help="Train tool grade models")
+    subparsers.add_parser("overall", help="Train overall grade predictor")
+    subparsers.add_parser("grades", help="Generate player grades")
+
+    args, unknown = parser.parse_known_args()
+
+    if args.command == "train":
+        train.main()
+    elif args.command == "overall":
+        overall_model.main()
+    elif args.command == "grades":
+        get_grades.main()
+    else:
+        parser.print_help()
+
 
 if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+pandas
+numpy
+scikit-learn
+lightgbm
+hyperopt
+pymc
+arviz
+pybaseball
+tqdm
+plotly
+dash


### PR DESCRIPTION
## Summary
- add gitignore and requirements
- implement CLI in `main.py`
- update README with project overview and usage

## Testing
- `python -m py_compile build_db.py etl.py get_grades.py grades_analyzer.py main.py toolgrade_sql.py constants.py overall_model.py train.py`

------
https://chatgpt.com/codex/tasks/task_e_68769c22bbcc8326bec0c87dc5a9db54